### PR TITLE
Update docker-compose.yml

### DIFF
--- a/nginx-golang/docker-compose.yml
+++ b/nginx-golang/docker-compose.yml
@@ -6,5 +6,7 @@ services:
       - 80:80
     depends_on:
       - backend
+    extra_hosts:
+      - "backend:172.24.121.152" #172.24.121.152 you host ip addr
   backend:
     build: backend


### PR DESCRIPTION
must add extra_hosts  
otherwide nginx conf can't  reslove ip add from “http://backend” in nginx.conf.

if not change this  config when I do command below , It will make mistake.
"docker-compose up"

[emerg] 1#1: host not found in upstream "backend" in /etc/nginx/conf.d/default.conf:5

